### PR TITLE
implemented FFTW Improvements

### DIFF
--- a/Systems/CMakeLists.txt
+++ b/Systems/CMakeLists.txt
@@ -36,17 +36,15 @@ if(USE_BLAS)
 endif()
 
 if(USE_FFTW)
-  find_package(PkgConfig QUIET)
+  find_path(FFTW3_INCLUDE_DIRS NAMES fftw3.h PATHS /opt/homebrew/include /usr/local/include /usr/include)
+  find_library(FFTW3_LIBRARIES NAMES fftw3 PATHS /opt/homebrew/lib /usr/local/lib /usr/lib)
+  find_library(FFTW3F_LIBRARIES NAMES fftw3f PATHS /opt/homebrew/lib /usr/local/lib /usr/lib)
 
-  if(PkgConfig_FOUND)
-    pkg_check_modules(FFTW3 QUIET fftw3)
-  endif()
-
-  if(FFTW3_FOUND)
+  if(FFTW3_INCLUDE_DIRS AND FFTW3_LIBRARIES AND FFTW3F_LIBRARIES)
     add_library(FFTW3::fftw3 INTERFACE IMPORTED)
     set_target_properties(FFTW3::fftw3 PROPERTIES
       INTERFACE_INCLUDE_DIRECTORIES "${FFTW3_INCLUDE_DIRS}"
-      INTERFACE_LINK_LIBRARIES "${FFTW3_LIBRARIES}"
+      INTERFACE_LINK_LIBRARIES "${FFTW3_LIBRARIES};${FFTW3F_LIBRARIES}"
     )
   else()
     message(FATAL_ERROR
@@ -101,4 +99,29 @@ else()
   if(CMAKE_CROSSCOMPILING)
     target_link_options(classify PRIVATE -static)
   endif()
+endif()
+
+# Build the FFTW wrapper tests
+add_executable(test_fftw_ops
+  src/tests/test_fftw_ops.cpp
+)
+
+target_include_directories(test_fftw_ops PRIVATE
+  src
+  src/vector
+)
+
+target_link_libraries(test_fftw_ops PRIVATE mdspan)
+
+if(USE_FFTW)
+  target_link_libraries(test_fftw_ops PRIVATE FFTW3::fftw3)
+  target_compile_definitions(test_fftw_ops PRIVATE USE_FFTW)
+endif()
+
+if(MSVC)
+  target_compile_options(test_fftw_ops PRIVATE /W4)
+else()
+  target_compile_options(test_fftw_ops PRIVATE
+    -O3 -Wall -Wextra -Wpedantic -march=native -mtune=native
+  )
 endif()

--- a/Systems/src/fft/fftw_ops.h
+++ b/Systems/src/fft/fftw_ops.h
@@ -4,6 +4,7 @@
 #include <type_traits>
 #include <complex>
 #include <concepts>
+#include <array>
 #include <fftw3.h>
 #include "../tensor.h"
 #include "fftw_wrapper.h"
@@ -69,13 +70,16 @@ private:
 
     void create_plan(TensorBase<val_t, E>& in, TensorBase<val_t, E>& out) {
         if (valid_) return;
-        static_assert(E::rank() == 1, "Currently only rank 1 tensors are supported for FFTW");
-        
-        int n = E::static_extent(0);
+
+        std::array<int, E::rank()> n{};
+        for (std::size_t i = 0; i < E::rank(); ++i) {
+            n[i] = static_cast<int>(E::static_extent(i));
+        }
+
         plan_ = traits::plan_dft(
-            1, &n, 
-            reinterpret_cast<typename traits::complex_t*>(in.data()), 
-            reinterpret_cast<typename traits::complex_t*>(out.data()), 
+            static_cast<int>(E::rank()), n.data(),
+            reinterpret_cast<typename traits::complex_t*>(in.data()),
+            reinterpret_cast<typename traits::complex_t*>(out.data()),
             Sign, Flags
         );
         valid_ = plan_ != nullptr;

--- a/Systems/src/fft/fftw_ops.h
+++ b/Systems/src/fft/fftw_ops.h
@@ -16,27 +16,41 @@ struct fftw_traits;
 
 template <>
 struct fftw_traits<float> {
+    using real_t = float;
     using plan_t = fftwf_plan;
     using complex_t = fftwf_complex;
     static constexpr auto plan_dft = fftwf_plan_dft;
+    static constexpr auto plan_dft_r2c = fftwf_plan_dft_r2c_1d;
+    static constexpr auto plan_dft_c2r = fftwf_plan_dft_c2r_1d;
     static constexpr auto execute = fftwf_execute;
     static constexpr auto execute_dft = fftwf_execute_dft;
+    static constexpr auto execute_dft_r2c = fftwf_execute_dft_r2c;
+    static constexpr auto execute_dft_c2r = fftwf_execute_dft_c2r;
     static constexpr auto destroy_plan = fftwf_destroy_plan;
 };
 
 template <>
 struct fftw_traits<double> {
+    using real_t = double;
     using plan_t = fftw_plan;
     using complex_t = fftw_complex;
     static constexpr auto plan_dft = fftw_plan_dft;
+    static constexpr auto plan_dft_r2c = fftw_plan_dft_r2c_1d;
+    static constexpr auto plan_dft_c2r = fftw_plan_dft_c2r_1d;
     static constexpr auto execute = fftw_execute;
     static constexpr auto execute_dft = fftw_execute_dft;
+    static constexpr auto execute_dft_r2c = fftw_execute_dft_r2c;
+    static constexpr auto execute_dft_c2r = fftw_execute_dft_c2r;
     static constexpr auto destroy_plan = fftw_destroy_plan;
 };
 
 // Also support std::complex mapping
 template <typename T>
 struct fftw_traits<std::complex<T>> : fftw_traits<T> {};
+
+// Helper to compute R2C Output Extent
+template <FixedExtent E>
+using R2CExtent = std::extents<size_t, (E::static_extent(0) / 2) + 1>;
 
 /**
  * Type-safe FFTW wrapper using TensorBase with compile-time extent checking
@@ -47,22 +61,14 @@ class FFTW {
 public:
     using traits = fftw_traits<T>;
     using plan_t = typename traits::plan_t;
-    using in_t = std::complex<typename std::conditional_t<std::is_same_v<T, float>, float, double>>;
-    // T could be float or std::complex<float>, we normalize it back to complex since FFTW expects complex.
-    using val_t = std::conditional_t<std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>>, T, std::complex<T>>;
+    using val_t = std::complex<typename traits::real_t>;
 
 private:
     plan_t plan_{nullptr};
     bool valid_{false};
 
-    // Helper to generate the plan
-    template <Allocator<val_t> AllocIn, Allocator<val_t> AllocOut>
-    void create_plan(DynTensor<val_t, E, AllocIn>& in, DynTensor<val_t, E, AllocOut>& out) {
+    void create_plan(TensorBase<val_t, E>& in, TensorBase<val_t, E>& out) {
         if (valid_) return;
-
-        // Since it's a fixed extent, we extract dimensions at compile time
-        // Note: For multi-dimensional, we can pass multiple dimensions, but here we assume rank 1 for simplicity of FFTW plan. 
-        // A full rank-N FFT would require fftw_plan_dft_X. For now, assuming rank 1 as a start.
         static_assert(E::rank() == 1, "Currently only rank 1 tensors are supported for FFTW");
         
         int n = E::static_extent(0);
@@ -77,12 +83,9 @@ private:
 
 public:
     FFTW() = default;
-    
-    // Disable copy
     FFTW(const FFTW&) = delete;
     FFTW& operator=(const FFTW&) = delete;
 
-    // Enable move
     FFTW(FFTW&& other) noexcept : plan_(other.plan_), valid_(other.valid_) {
         other.plan_ = nullptr;
         other.valid_ = false;
@@ -102,37 +105,175 @@ public:
         if (valid_) traits::destroy_plan(plan_);
     }
 
-    /**
-     * Executes the FFT plan using in and out tensors.
-     * Tensors must have the exact same rank and extents as established by FixedExtent E.
-     */
-    template <Allocator<val_t> AllocIn, Allocator<val_t> AllocOut>
-    void operator()(DynTensor<val_t, E, AllocIn>& in, DynTensor<val_t, E, AllocOut>& out) {
+    void operator()(TensorBase<val_t, E>& in, TensorBase<val_t, E>& out) {
         if (!valid_) {
             create_plan(in, out);
         }
-        
-        // Execute the plan
-        // If pointers match the one generated at planning time, `execute` is perfectly safe
-        // If not, execute_dft must be used for new array pointers
         traits::execute_dft(plan_, 
             reinterpret_cast<typename traits::complex_t*>(in.data()), 
             reinterpret_cast<typename traits::complex_t*>(out.data()));
     }
 
-    /**
-     * Integration with the expression system.
-     * Materializes the expression into `temp_in`, then performs the FFT, saving into `out`.
-     */
-    template <Expression Expr, Allocator<val_t> AllocIn, Allocator<val_t> AllocOut>
-    void eval(const Expr& expr, DynTensor<val_t, E, AllocIn>& temp_in, DynTensor<val_t, E, AllocOut>& out) {
+    template <Expression Expr>
+    void eval(const Expr& expr, TensorBase<val_t, E>& temp_in, TensorBase<val_t, E>& out) {
         static_assert(Expr::iter_size() == compute_static_size<E>(),
             "FFTW eval: expression size must match tensor size");
 
         for (size_t i = 0; i < Expr::iter_size(); ++i) {
             temp_in.flat(i) = expr.access(i);
         }
+        this->operator()(temp_in, out);
+    }
+};
 
+/**
+ * Real-to-Complex Transform
+ * Input is a real Tensor, Output is a complex Tensor of size N/2 + 1.
+ */
+template <typename T, FixedExtent E, unsigned Flags = FFTW_ESTIMATE>
+class FFTW_R2C {
+public:
+    using traits = fftw_traits<T>;
+    using plan_t = typename traits::plan_t;
+    using real_t = typename traits::real_t;
+    using complex_t = std::complex<real_t>;
+    using OutExtent = R2CExtent<E>;
+
+private:
+    plan_t plan_{nullptr};
+    bool valid_{false};
+
+    void create_plan(TensorBase<real_t, E>& in, TensorBase<complex_t, OutExtent>& out) {
+        if (valid_) return;
+        static_assert(E::rank() == 1, "Currently only rank 1 tensors are supported for FFTW_R2C");
+        
+        int n = E::static_extent(0);
+        plan_ = traits::plan_dft_r2c(
+            n, 
+            reinterpret_cast<real_t*>(in.data()), 
+            reinterpret_cast<typename traits::complex_t*>(out.data()), 
+            Flags
+        );
+        valid_ = plan_ != nullptr;
+    }
+
+public:
+    FFTW_R2C() = default;
+    FFTW_R2C(const FFTW_R2C&) = delete;
+    FFTW_R2C& operator=(const FFTW_R2C&) = delete;
+
+    FFTW_R2C(FFTW_R2C&& other) noexcept : plan_(other.plan_), valid_(other.valid_) {
+        other.plan_ = nullptr;
+        other.valid_ = false;
+    }
+    FFTW_R2C& operator=(FFTW_R2C&& other) noexcept {
+        if (this != &other) {
+            if (valid_) traits::destroy_plan(plan_);
+            plan_ = other.plan_;
+            valid_ = other.valid_;
+            other.plan_ = nullptr;
+            other.valid_ = false;
+        }
+        return *this;
+    }
+
+    ~FFTW_R2C() {
+        if (valid_) traits::destroy_plan(plan_);
+    }
+
+    void operator()(TensorBase<real_t, E>& in, TensorBase<complex_t, OutExtent>& out) {
+        if (!valid_) {
+            create_plan(in, out);
+        }
+        traits::execute_dft_r2c(plan_, 
+            reinterpret_cast<real_t*>(in.data()), 
+            reinterpret_cast<typename traits::complex_t*>(out.data()));
+    }
+
+    template <Expression Expr>
+    void eval(const Expr& expr, TensorBase<real_t, E>& temp_in, TensorBase<complex_t, OutExtent>& out) {
+        static_assert(Expr::iter_size() == compute_static_size<E>(),
+            "FFTW_R2C eval: expression size must match tensor size");
+
+        for (size_t i = 0; i < Expr::iter_size(); ++i) {
+            temp_in.flat(i) = expr.access(i);
+        }
+        this->operator()(temp_in, out);
+    }
+};
+
+/**
+ * Complex-to-Real Transform
+ * Input is a complex Tensor of size N/2 + 1, Output is a real Tensor of size N.
+ */
+template <typename T, FixedExtent OutE, unsigned Flags = FFTW_ESTIMATE>
+class FFTW_C2R {
+public:
+    using traits = fftw_traits<T>;
+    using plan_t = typename traits::plan_t;
+    using real_t = typename traits::real_t;
+    using complex_t = std::complex<real_t>;
+    using InExtent = R2CExtent<OutE>;
+
+private:
+    plan_t plan_{nullptr};
+    bool valid_{false};
+
+    void create_plan(TensorBase<complex_t, InExtent>& in, TensorBase<real_t, OutE>& out) {
+        if (valid_) return;
+        static_assert(OutE::rank() == 1, "Currently only rank 1 tensors are supported for FFTW_C2R");
+        
+        int n = OutE::static_extent(0);
+        plan_ = traits::plan_dft_c2r(
+            n, 
+            reinterpret_cast<typename traits::complex_t*>(in.data()), 
+            reinterpret_cast<real_t*>(out.data()), 
+            Flags
+        );
+        valid_ = plan_ != nullptr;
+    }
+
+public:
+    FFTW_C2R() = default;
+    FFTW_C2R(const FFTW_C2R&) = delete;
+    FFTW_C2R& operator=(const FFTW_C2R&) = delete;
+
+    FFTW_C2R(FFTW_C2R&& other) noexcept : plan_(other.plan_), valid_(other.valid_) {
+        other.plan_ = nullptr;
+        other.valid_ = false;
+    }
+    FFTW_C2R& operator=(FFTW_C2R&& other) noexcept {
+        if (this != &other) {
+            if (valid_) traits::destroy_plan(plan_);
+            plan_ = other.plan_;
+            valid_ = other.valid_;
+            other.plan_ = nullptr;
+            other.valid_ = false;
+        }
+        return *this;
+    }
+
+    ~FFTW_C2R() {
+        if (valid_) traits::destroy_plan(plan_);
+    }
+
+    void operator()(TensorBase<complex_t, InExtent>& in, TensorBase<real_t, OutE>& out) {
+        if (!valid_) {
+            create_plan(in, out);
+        }
+        traits::execute_dft_c2r(plan_, 
+            reinterpret_cast<typename traits::complex_t*>(in.data()), 
+            reinterpret_cast<real_t*>(out.data()));
+    }
+
+    template <Expression Expr>
+    void eval(const Expr& expr, TensorBase<complex_t, InExtent>& temp_in, TensorBase<real_t, OutE>& out) {
+        static_assert(Expr::iter_size() == compute_static_size<InExtent>(),
+            "FFTW_C2R eval: expression size must match tensor size");
+
+        for (size_t i = 0; i < Expr::iter_size(); ++i) {
+            temp_in.flat(i) = expr.access(i);
+        }
         this->operator()(temp_in, out);
     }
 };

--- a/Systems/src/fft/fftw_ops.h
+++ b/Systems/src/fft/fftw_ops.h
@@ -1,0 +1,142 @@
+#ifndef __FFTW_OPS_H__
+#define __FFTW_OPS_H__
+
+#include <type_traits>
+#include <complex>
+#include <concepts>
+#include <fftw3.h>
+#include "../tensor.h"
+#include "fftw_wrapper.h"
+
+namespace fft {
+
+// Type trait mapping float/double to their respective FFTW configurations
+template <typename T>
+struct fftw_traits;
+
+template <>
+struct fftw_traits<float> {
+    using plan_t = fftwf_plan;
+    using complex_t = fftwf_complex;
+    static constexpr auto plan_dft = fftwf_plan_dft;
+    static constexpr auto execute = fftwf_execute;
+    static constexpr auto execute_dft = fftwf_execute_dft;
+    static constexpr auto destroy_plan = fftwf_destroy_plan;
+};
+
+template <>
+struct fftw_traits<double> {
+    using plan_t = fftw_plan;
+    using complex_t = fftw_complex;
+    static constexpr auto plan_dft = fftw_plan_dft;
+    static constexpr auto execute = fftw_execute;
+    static constexpr auto execute_dft = fftw_execute_dft;
+    static constexpr auto destroy_plan = fftw_destroy_plan;
+};
+
+// Also support std::complex mapping
+template <typename T>
+struct fftw_traits<std::complex<T>> : fftw_traits<T> {};
+
+/**
+ * Type-safe FFTW wrapper using TensorBase with compile-time extent checking
+ * Provides memory management of plans and safe `operator()` overloading for evaluation
+ */
+template <typename T, FixedExtent E, int Sign = FFTW_FORWARD, unsigned Flags = FFTW_ESTIMATE>
+class FFTW {
+public:
+    using traits = fftw_traits<T>;
+    using plan_t = typename traits::plan_t;
+    using in_t = std::complex<typename std::conditional_t<std::is_same_v<T, float>, float, double>>;
+    // T could be float or std::complex<float>, we normalize it back to complex since FFTW expects complex.
+    using val_t = std::conditional_t<std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>>, T, std::complex<T>>;
+
+private:
+    plan_t plan_{nullptr};
+    bool valid_{false};
+
+    // Helper to generate the plan
+    template <Allocator<val_t> AllocIn, Allocator<val_t> AllocOut>
+    void create_plan(DynTensor<val_t, E, AllocIn>& in, DynTensor<val_t, E, AllocOut>& out) {
+        if (valid_) return;
+
+        // Since it's a fixed extent, we extract dimensions at compile time
+        // Note: For multi-dimensional, we can pass multiple dimensions, but here we assume rank 1 for simplicity of FFTW plan. 
+        // A full rank-N FFT would require fftw_plan_dft_X. For now, assuming rank 1 as a start.
+        static_assert(E::rank() == 1, "Currently only rank 1 tensors are supported for FFTW");
+        
+        int n = E::static_extent(0);
+        plan_ = traits::plan_dft(
+            1, &n, 
+            reinterpret_cast<typename traits::complex_t*>(in.data()), 
+            reinterpret_cast<typename traits::complex_t*>(out.data()), 
+            Sign, Flags
+        );
+        valid_ = plan_ != nullptr;
+    }
+
+public:
+    FFTW() = default;
+    
+    // Disable copy
+    FFTW(const FFTW&) = delete;
+    FFTW& operator=(const FFTW&) = delete;
+
+    // Enable move
+    FFTW(FFTW&& other) noexcept : plan_(other.plan_), valid_(other.valid_) {
+        other.plan_ = nullptr;
+        other.valid_ = false;
+    }
+    FFTW& operator=(FFTW&& other) noexcept {
+        if (this != &other) {
+            if (valid_) traits::destroy_plan(plan_);
+            plan_ = other.plan_;
+            valid_ = other.valid_;
+            other.plan_ = nullptr;
+            other.valid_ = false;
+        }
+        return *this;
+    }
+
+    ~FFTW() {
+        if (valid_) traits::destroy_plan(plan_);
+    }
+
+    /**
+     * Executes the FFT plan using in and out tensors.
+     * Tensors must have the exact same rank and extents as established by FixedExtent E.
+     */
+    template <Allocator<val_t> AllocIn, Allocator<val_t> AllocOut>
+    void operator()(DynTensor<val_t, E, AllocIn>& in, DynTensor<val_t, E, AllocOut>& out) {
+        if (!valid_) {
+            create_plan(in, out);
+        }
+        
+        // Execute the plan
+        // If pointers match the one generated at planning time, `execute` is perfectly safe
+        // If not, execute_dft must be used for new array pointers
+        traits::execute_dft(plan_, 
+            reinterpret_cast<typename traits::complex_t*>(in.data()), 
+            reinterpret_cast<typename traits::complex_t*>(out.data()));
+    }
+
+    /**
+     * Integration with the expression system.
+     * Materializes the expression into `temp_in`, then performs the FFT, saving into `out`.
+     */
+    template <Expression Expr, Allocator<val_t> AllocIn, Allocator<val_t> AllocOut>
+    void eval(const Expr& expr, DynTensor<val_t, E, AllocIn>& temp_in, DynTensor<val_t, E, AllocOut>& out) {
+        static_assert(Expr::iter_size() == compute_static_size<E>(),
+            "FFTW eval: expression size must match tensor size");
+
+        for (size_t i = 0; i < Expr::iter_size(); ++i) {
+            temp_in.flat(i) = expr.access(i);
+        }
+
+        this->operator()(temp_in, out);
+    }
+};
+
+} // namespace fft
+
+#endif

--- a/Systems/src/fft/fftw_ops.md
+++ b/Systems/src/fft/fftw_ops.md
@@ -9,22 +9,27 @@ This file provides a type-safe object-oriented wrapper around the FFTW library. 
 A type trait mapping `float`, `double`, and `std::complex` variations to their underlying FFTW functions (`fftw_plan_dft`, `fftwf_execute`, etc.) and data types, avoiding duplicate implementation loops.
 
 ### `template <typename T, FixedExtent E, int Sign = FFTW_FORWARD, unsigned Flags = FFTW_ESTIMATE> class FFTW;`
-
-The main Fourier Transform handler. 
+The main Complex-to-Complex Fourier Transform handler. 
 
 - `T`: The underlying floating point type or complex type (`float`, `double`, `std::complex<float>`, `std::complex<double>`).
 - `E`: Complete `std::extents` specification defining the shape of the transformation. Only single-rank transforms are currently supported. 
 - `Sign`: Represents the transform direction (`FFTW_FORWARD`, `FFTW_BACKWARD`).
 - `Flags`: Defines FFTW optimization efforts for this particular plan (e.g., `FFTW_MEASURE` vs `FFTW_ESTIMATE`).
 
+### `template <typename T, FixedExtent E, unsigned Flags = FFTW_ESTIMATE> class FFTW_R2C;`
+The Real-to-Complex Fourier Transform handler. Converts a real layout tensor into an optimally smaller complex layout representing mirrored frequency domain buckets. 
+
+### `template <typename T, FixedExtent OutE, unsigned Flags = FFTW_ESTIMATE> class FFTW_C2R;`
+The Complex-to-Real Fourier Transform handler. Restores a real layout tensor from a half-length frequency format mirrored structure.
+
 #### Constructor
-- `FFTW() = default;`
-  Instances are generated empty. The internal `plan_` will only be concretized via `create_plan()` internally upon its first invocation against actual memory blocks. Copying is disabled, but move construction/assignment is permitted. 
+- `FFTW() = default;` (Same for `FFTW_R2C` and `FFTW_C2R`)
+  Instances are generated empty. The internal `plan_` will only be concretized via an internal `create_plan()` internally upon its first invocation against actual memory blocks. Copying is disabled, but move construction/assignment is permitted. 
 
 #### Methods
 
-- `template <Allocator<val_t> AllocIn, Allocator<val_t> AllocOut> void operator()(DynTensor<val_t, E, AllocIn>& in, DynTensor<val_t, E, AllocOut>& out);`
-  The main interaction point. Performs the FFT and stores it in `out`. At compile-time, this checks that the `in` and `out` arrays exactly match the dimensions expected by `E`.
+- `void operator()(TensorBase<in_t, E>& in, TensorBase<out_t, OutExtent>& out);`
+  The main interaction point. Performs the FFT and stores it in `out`. At compile-time, this checks that the `in` and `out` arrays match exactly the memory dimensions required by the transformation direction. Using `TensorBase` references allows seamless generic mapping directly from `DynTensor` or externally managed raw buffers alike.
 
-- `template <Expression Expr, Allocator<val_t> AllocIn, Allocator<val_t> AllocOut> void eval(const Expr& expr, DynTensor<val_t, E, AllocIn>& temp_in, DynTensor<val_t, E, AllocOut>& out);`
+- `template <Expression Expr> void eval(const Expr& expr, TensorBase<in_t, E>& temp_in, TensorBase<out_t, OutExtent>& out);`
   Materializes any generic math `Expression` into the `temp_in` sequence using iterator bindings, then automatically invokes `operator()` to produce `out`. The shape validation relies on compile-time checks making sure `expr::iter_size() == compute_static_size<E>()`.

--- a/Systems/src/fft/fftw_ops.md
+++ b/Systems/src/fft/fftw_ops.md
@@ -1,0 +1,30 @@
+# fftw_ops.h Documentation
+
+## Description
+This file provides a type-safe object-oriented wrapper around the FFTW library. It bridges the gap between raw `fftw_complex` C arrays and `TensorBase`, bringing compile-time optimizations and expression-system integrations to Fourier transforms.
+
+## Classes
+
+### `template <typename T> struct fftw_traits;`
+A type trait mapping `float`, `double`, and `std::complex` variations to their underlying FFTW functions (`fftw_plan_dft`, `fftwf_execute`, etc.) and data types, avoiding duplicate implementation loops.
+
+### `template <typename T, FixedExtent E, int Sign = FFTW_FORWARD, unsigned Flags = FFTW_ESTIMATE> class FFTW;`
+
+The main Fourier Transform handler. 
+
+- `T`: The underlying floating point type or complex type (`float`, `double`, `std::complex<float>`, `std::complex<double>`).
+- `E`: Complete `std::extents` specification defining the shape of the transformation. Only single-rank transforms are currently supported. 
+- `Sign`: Represents the transform direction (`FFTW_FORWARD`, `FFTW_BACKWARD`).
+- `Flags`: Defines FFTW optimization efforts for this particular plan (e.g., `FFTW_MEASURE` vs `FFTW_ESTIMATE`).
+
+#### Constructor
+- `FFTW() = default;`
+  Instances are generated empty. The internal `plan_` will only be concretized via `create_plan()` internally upon its first invocation against actual memory blocks. Copying is disabled, but move construction/assignment is permitted. 
+
+#### Methods
+
+- `template <Allocator<val_t> AllocIn, Allocator<val_t> AllocOut> void operator()(DynTensor<val_t, E, AllocIn>& in, DynTensor<val_t, E, AllocOut>& out);`
+  The main interaction point. Performs the FFT and stores it in `out`. At compile-time, this checks that the `in` and `out` arrays exactly match the dimensions expected by `E`.
+
+- `template <Expression Expr, Allocator<val_t> AllocIn, Allocator<val_t> AllocOut> void eval(const Expr& expr, DynTensor<val_t, E, AllocIn>& temp_in, DynTensor<val_t, E, AllocOut>& out);`
+  Materializes any generic math `Expression` into the `temp_in` sequence using iterator bindings, then automatically invokes `operator()` to produce `out`. The shape validation relies on compile-time checks making sure `expr::iter_size() == compute_static_size<E>()`.

--- a/Systems/src/fft/fftw_ops.md
+++ b/Systems/src/fft/fftw_ops.md
@@ -12,15 +12,15 @@ A type trait mapping `float`, `double`, and `std::complex` variations to their u
 The main Complex-to-Complex Fourier Transform handler. 
 
 - `T`: The underlying floating point type or complex type (`float`, `double`, `std::complex<float>`, `std::complex<double>`).
-- `E`: Complete `std::extents` specification defining the shape of the transformation. Only single-rank transforms are currently supported. 
+- `E`: Complete `std::extents` specification defining the shape of the transformation. Arbitrary rank is supported; the extents are materialized into a stack `std::array<int, E::rank()>` at plan-creation time and forwarded to `fftw_plan_dft(rank, n, ...)`.
 - `Sign`: Represents the transform direction (`FFTW_FORWARD`, `FFTW_BACKWARD`).
 - `Flags`: Defines FFTW optimization efforts for this particular plan (e.g., `FFTW_MEASURE` vs `FFTW_ESTIMATE`).
 
 ### `template <typename T, FixedExtent E, unsigned Flags = FFTW_ESTIMATE> class FFTW_R2C;`
-The Real-to-Complex Fourier Transform handler. Converts a real layout tensor into an optimally smaller complex layout representing mirrored frequency domain buckets. 
+The Real-to-Complex Fourier Transform handler. Converts a real layout tensor into an optimally smaller complex layout representing mirrored frequency domain buckets. Currently rank-1 only (uses the FFTW 1D entry point `fftw_plan_dft_r2c_1d`).
 
 ### `template <typename T, FixedExtent OutE, unsigned Flags = FFTW_ESTIMATE> class FFTW_C2R;`
-The Complex-to-Real Fourier Transform handler. Restores a real layout tensor from a half-length frequency format mirrored structure.
+The Complex-to-Real Fourier Transform handler. Restores a real layout tensor from a half-length frequency format mirrored structure. Currently rank-1 only (uses the FFTW 1D entry point `fftw_plan_dft_c2r_1d`).
 
 #### Constructor
 - `FFTW() = default;` (Same for `FFTW_R2C` and `FFTW_C2R`)

--- a/Systems/src/memorybuffer.h
+++ b/Systems/src/memorybuffer.h
@@ -75,7 +75,7 @@ class MemoryBuffer {
         template<class U, std::size_t UAlignment = Alignment> struct rebind { using other = Allocator<U, UAlignment>; };
 
         T* allocate(std::size_t n) {
-            return buffer.get().alloc<T, Alignment>(n);
+            return buffer.get().template alloc<T, Alignment>(n);
         }
 
         void deallocate([[maybe_unused]] T* p, [[maybe_unused]] std::size_t n) {}  // no-op for bump allocator

--- a/Systems/src/tests/test_fftw_ops.cpp
+++ b/Systems/src/tests/test_fftw_ops.cpp
@@ -122,6 +122,38 @@ void test_r2c() {
     TEST("R2C AC", approx_equal(out.flat(1).real(), 0.0f));
 }
 
+void test_rank2_c2c() {
+    using Extent = std::extents<size_t, 4, 4>;
+    using T = std::complex<float>;
+
+    DynTensor<T, Extent> in;
+    DynTensor<T, Extent> out;
+
+    for (size_t i = 0; i < 16; ++i) {
+        in.flat(i) = T(0.0f, 0.0f);
+    }
+    for (size_t i = 0; i < 4; ++i) {
+        in.flat(i * 4 + 0) = T(1.0f, 0.0f);
+    }
+
+    FFTW<float, Extent, FFTW_FORWARD, FFTW_ESTIMATE> fft;
+    fft(in, out);
+
+    bool row0_ok = true;
+    for (size_t k2 = 0; k2 < 4; ++k2) {
+        if (!approx_equal(out.flat(k2).real(), 4.0f)) row0_ok = false;
+        if (!approx_equal(out.flat(k2).imag(), 0.0f)) row0_ok = false;
+    }
+    TEST("Rank-2 C2C Row 0 == 4", row0_ok);
+
+    bool rest_zero = true;
+    for (size_t i = 4; i < 16; ++i) {
+        if (!approx_equal(out.flat(i).real(), 0.0f)) rest_zero = false;
+        if (!approx_equal(out.flat(i).imag(), 0.0f)) rest_zero = false;
+    }
+    TEST("Rank-2 C2C Others == 0", rest_zero);
+}
+
 void test_c2r() {
     using OutExtent = std::extents<size_t, 4>;
     using RealT = float;
@@ -147,6 +179,7 @@ int main() {
     test_basic_plan();
     test_eval_integration();
     test_custom_allocator();
+    test_rank2_c2c();
     test_r2c();
     test_c2r();
     

--- a/Systems/src/tests/test_fftw_ops.cpp
+++ b/Systems/src/tests/test_fftw_ops.cpp
@@ -102,12 +102,53 @@ void test_custom_allocator() {
     TEST("Custom Allocator Others Zero", others_zero);
 }
 
+void test_r2c() {
+    using Extent = std::extents<size_t, 4>;
+    using RealT = float;
+    using CpxT = std::complex<float>;
+
+    DynTensor<RealT, Extent> in;
+    DynTensor<CpxT, fft::R2CExtent<Extent>> out;
+
+    for (size_t i = 0; i < 4; ++i) {
+        in.flat(i) = 1.0f;
+    }
+
+    FFTW_R2C<float, Extent> fft;
+    fft(in, out);
+
+    TEST("R2C DC Real", approx_equal(out.flat(0).real(), 4.0f));
+    TEST("R2C DC Imag", approx_equal(out.flat(0).imag(), 0.0f));
+    TEST("R2C AC", approx_equal(out.flat(1).real(), 0.0f));
+}
+
+void test_c2r() {
+    using OutExtent = std::extents<size_t, 4>;
+    using RealT = float;
+    using CpxT = std::complex<float>;
+
+    DynTensor<CpxT, fft::R2CExtent<OutExtent>> in;
+    DynTensor<RealT, OutExtent> out;
+
+    in.flat(0) = CpxT(4.0f, 0.0f);
+    in.flat(1) = CpxT(0.0f, 0.0f);
+    in.flat(2) = CpxT(0.0f, 0.0f);
+
+    FFTW_C2R<float, OutExtent> ifft;
+    ifft(in, out);
+
+    TEST("C2R DC", approx_equal(out.flat(0), 4.0f));
+    TEST("C2R AC", approx_equal(out.flat(1), 4.0f));
+}
+
 int main() {
     std::cout << "\n=== FFTW Wrapper Tests ===\n\n";
     
     test_basic_plan();
     test_eval_integration();
     test_custom_allocator();
+    test_r2c();
+    test_c2r();
     
     std::cout << "\n" << passed << "/" << total << " tests passed\n\n";
     return (passed == total) ? 0 : 1;

--- a/Systems/src/tests/test_fftw_ops.cpp
+++ b/Systems/src/tests/test_fftw_ops.cpp
@@ -1,0 +1,114 @@
+#include <iostream>
+#include <complex>
+#include <vector>
+#include <cmath>
+
+#include "../fft/fftw_ops.h"
+#include "../memorybuffer.h"
+#include "../tensor.h"
+#include "../ExprSystem/Expression.h"
+
+using namespace fft;
+
+int passed = 0, total = 0;
+
+#define TEST(name, condition) \
+    total++; \
+    if (condition) { \
+        passed++; \
+        std::cout << "✓ " << name << "\n"; \
+    } else { \
+        std::cout << "✗ " << name << "\n"; \
+    }
+
+bool approx_equal(double a, double b, double epsilon = 1e-5) {
+    return std::abs(a - b) < epsilon;
+}
+
+void test_basic_plan() {
+    using Extent = std::extents<size_t, 8>;
+    using T = std::complex<float>;
+
+    DynTensor<T, Extent> in;
+    DynTensor<T, Extent> out;
+
+    for (size_t i = 0; i < 8; ++i) {
+        in.flat(i) = T(static_cast<float>(i), 0.0f);
+    }
+
+    FFTW<float, Extent, FFTW_FORWARD, FFTW_ESTIMATE> fft;
+    fft(in, out);
+
+    // DC component (sum of inputs) should be 28
+    TEST("Basic Plan DC Real", approx_equal(out.flat(0).real(), 28.0f));
+    TEST("Basic Plan DC Imag", approx_equal(out.flat(0).imag(), 0.0f));
+}
+
+template<class T, class Extent>
+struct DummyExpr {
+    static constexpr auto extents = Extent{};
+    using value_type = T;
+    static constexpr size_t iter_size() noexcept { return 4; }
+    
+    constexpr T access(size_t i) const noexcept {
+        return T(static_cast<double>(i * 2), 0.0);
+    }
+};
+
+void test_eval_integration() {
+    using Extent = std::extents<size_t, 4>;
+    using T = std::complex<double>;
+
+    DynTensor<T, Extent> out;
+    DynTensor<T, Extent> temp_in;
+
+    DummyExpr<T, Extent> expr;
+    FFTW<double, Extent, FFTW_FORWARD, FFTW_ESTIMATE> fft;
+    
+    fft.eval(expr, temp_in, out);
+
+    // Sum is 0 + 2 + 4 + 6 = 12
+    TEST("Eval Integration DC Real", approx_equal(out.flat(0).real(), 12.0));
+    TEST("Eval Integration DC Imag", approx_equal(out.flat(0).imag(), 0.0));
+}
+
+void test_custom_allocator() {
+    using Extent = std::extents<size_t, 16>;
+    using T = std::complex<float>;
+
+    MemoryBuffer buf(1024);
+    auto alloc = buf.get_allocator<T, 32>();
+
+    DynTensor<T, Extent, decltype(alloc)> in(alloc);
+    DynTensor<T, Extent, decltype(alloc)> out(alloc);
+
+    for (size_t i = 0; i < 16; ++i) {
+        in.flat(i) = T(1.0f, 0.0f);
+    }
+
+    FFTW<float, Extent> fft;
+    fft(in, out);
+
+    // DC is 16, others are 0
+    TEST("Custom Allocator DC Real", approx_equal(out.flat(0).real(), 16.0f));
+    TEST("Custom Allocator DC Imag", approx_equal(out.flat(0).imag(), 0.0f));
+    
+    bool others_zero = true;
+    for (size_t i = 1; i < 16; ++i) {
+        if (!approx_equal(out.flat(i).real(), 0.0f) || !approx_equal(out.flat(i).imag(), 0.0f)) {
+            others_zero = false;
+        }
+    }
+    TEST("Custom Allocator Others Zero", others_zero);
+}
+
+int main() {
+    std::cout << "\n=== FFTW Wrapper Tests ===\n\n";
+    
+    test_basic_plan();
+    test_eval_integration();
+    test_custom_allocator();
+    
+    std::cout << "\n" << passed << "/" << total << " tests passed\n\n";
+    return (passed == total) ? 0 : 1;
+}


### PR DESCRIPTION
closes #50 

**Summary**
This PR replaces the raw FFTW routines with a new type-safe FFTW class template capable of natively integrating with both the TensorBase multidimensional layout and the Expression engine. It handles all raw fftw_plan / fftwf_plan management internally via RAII and type-traits. Compilation safety is greatly improved, as dimensional extent correctness between the instance, the input tensor, and output tensor is statically verified at compile time via <FixedExtent E>, removing accidental length mismatches during DSP operations. Moreover, the integration naturally maps memory correctly via 32-byte alignments, allowing the underlying hardware and OpenBLAS structures to vectorize efficiently.

**Key Features Added** 
- fftw_traits map for auto-resolution between float and double and memory mapping for complex variants.
- Wrote FFTW<T, Extent, Sign, Flags> logic to construct fftw(f)_plan_dft configurations safely. Includes eval() method to easily execute evaluation-graphs into intermediate matrices before running the transformation process.
- Modified CMakeLists.txt to properly inject explicit dependencies on libfftw3 and libfftw3f rather than depending on PkgConfig which defaults to unavailable on macOS homebrew setups.
- Updated unit test infrastructure test_fftw_ops.cpp utilizing a lightweight macro-system directly testing edge cases inside src/tests.

**Next Steps**
Port existing references of fftw_wrapper.h functions to use the new FFTW class directly inline with Tensor objects.
Validate and benchmark the throughput advantage on longer RF captures comparing execution via Expression pipeline vs distinct loops natively utilizing AVX/ASIMD over the 32-bye aligned MemoryBuffer.